### PR TITLE
[26] - Add imageUrl to CreatePlant request

### DIFF
--- a/plant_monitoring.py
+++ b/plant_monitoring.py
@@ -42,6 +42,7 @@ class CreatePlant(BaseModel):
     type: str
     location: str
     description: str
+    imageUrl: str = ""
 
 
 class SensorOutput(BaseModel):
@@ -262,6 +263,8 @@ async def create_plant(plant: CreatePlant, current_user: dict = Security(get_cur
     
     try:
         plant = jsonable_encoder(plant)
+        if "imageUrl" not in plant:
+            plant["imageUrl"] = ""
         new_plant = await db["plants"].insert_one(plant)
         return JSONResponse(status_code=status.HTTP_201_CREATED, content={"_id": str(new_plant.inserted_id)})
     except Exception as e:


### PR DESCRIPTION
CreatePlant Endpoint should also include image url property even if it is empty.

- Add a default value for imageUrl in the CreatePlant model.
- Ensure that if imageUrl is not provided, it defaults to an empty string.